### PR TITLE
PoC async fn as a Handler

### DIFF
--- a/examples/path/introduction/Cargo.toml
+++ b/examples/path/introduction/Cargo.toml
@@ -4,6 +4,7 @@ description = "An introduction to extracting request path segments, in a type sa
 version = "0.0.0"
 authors = ["Nicolas Pochet <npochet@gmail.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -44,7 +44,9 @@ struct PathExtractor {
 }
 
 /// Handler function for `GET` requests directed to `/products/:name`
-fn get_product_handler(state: State) -> (State, String) {
+async fn get_product_handler(
+    state: State,
+) -> Result<(State, String), (State, gotham::handler::HandlerError)> {
     let message = {
         // Access the `PathExtractor` instance from `state` which was put there for us by the
         // `Router` during request evaluation.
@@ -56,7 +58,7 @@ fn get_product_handler(state: State) -> (State, String) {
         format!("Product: {}", product.name)
     };
 
-    (state, message)
+    Ok((state, message))
 }
 
 /// Create a `Router`


### PR DESCRIPTION
This is a PoC that we https://github.com/gotham-rs/gotham/pull/370#issuecomment-557242564 can allow `async fn` to impl `Handler` if we want to.

It's not the cleanest code. Sorry.

Hopefully it's readable enough to get the idea across.

Unfortunately, if we `impl IntoHandlerFuture for F where F: SomeTrait` then we cannot also `impl impl IntoHandlerFuture for (State, T)` (E0119), so I had to delete that impl. The only reason that we could get away with the previous pair of impls is that `(State, T)` and `Box<HandlerFuture>` are both structs, so the compiler can guarantee that it will always be able to disambiguate the two.

If we want to support the convenience `(State, T)` return type, we might be able to do this with a new `.to_simple()` function in the router builder. We might even be able to add a `.to_compat()` function, which takes an old-style future.